### PR TITLE
Have git ignore .bak files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -116,3 +116,6 @@ vendor/bundle/*
 
 #ignore jetbrains ide file
 *.iml
+
+# Ignore Salt file.replace state module backups created in-place.
+*.bak


### PR DESCRIPTION
The easiest alternative is to not create them in the first place, which is not ideal.